### PR TITLE
Fix compilation with DEBUG=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ all: $(TARGET)
 ifeq ($(DEBUG),0)
    FLAGS += -O2 $(EXTRA_GCC_FLAGS)
 else
-   FLAGS += -O0
+   FLAGS += -Og
 endif
 
 LDFLAGS += $(fpic) $(SHARED)


### PR DESCRIPTION
The core fails to build with DEBUG=1 because it relies on symbols being optimized out. Therefore switch from O0 to Og (optimize for debugging).

libretro.o: In function `port_rbyte(int&, unsigned int)':
libretro.cpp:(.text+0x784): undefined reference to `HuC6273_Read8(unsigned int)'
libretro.cpp:(.text+0x7e4): undefined reference to `FXSCSI_CtrlRead(unsigned int)'
libretro.o: In function `port_rhword(int&, unsigned int)':
libretro.cpp:(.text+0xa1f): undefined reference to `HuC6273_Read16(unsigned int)'
libretro.cpp:(.text+0xa8b): undefined reference to `FXSCSI_CtrlRead(unsigned int)'
libretro.o: In function `port_wbyte(int&, unsigned int, unsigned char)':
libretro.cpp:(.text+0xcfe): undefined reference to `HuC6273_Write16(unsigned int, unsigned short)'
libretro.cpp:(.text+0xd2e): undefined reference to `FXSCSI_CtrlWrite(unsigned int, unsigned char)'
(...)