### PR TITLE
Fix for audio clicks

### DIFF
--- a/mednafen/settings.cpp
+++ b/mednafen/settings.cpp
@@ -80,7 +80,7 @@ bool MDFN_GetSettingB(const char *name)
    if (!strcmp("pcfx.nospritelimit", name))
       return 0; /* TODO - make configurable */
    if (!strcmp("pcfx.adpcm.suppress_channel_reset_clicks", name))
-      return 0; /* TODO - make configurable */
+      return 1; /* TODO - make configurable */
    if (!strcmp("pcfx.disable_bram", name))
       return 0; /* TODO - make configurable */
    if (!strcmp("pcfx.adpcm.emulate_buggy_codec", name))


### PR DESCRIPTION
From mednafen documentation "Hack to suppress clicks caused by forced channel resets. default=1"

mednafen default for this value is "1" and i think static MDFNSetting PCFXSettings[] = is not passing options yet to core. i do not see anywhere else to set that option. im no developer so please implement this the way it should. thanks