### PR TITLE
correct BIOS typo in port from Medanfen standalone

### DIFF
--- a/mednafen/settings.cpp
+++ b/mednafen/settings.cpp
@@ -105,7 +105,7 @@ extern std::string retro_base_name;
 std::string MDFN_GetSettingS(const char *name)
 {
    if (!strcmp("pcfx.bios", name))
-      return std::string("pcfx.bios");
+      return std::string("pcfx.rom");
    if (!strcmp("pcfx.fxscsi", name))
       return std::string("pcfx.fxscsi");
    /* FILESYS */


### PR DESCRIPTION
In Mednafen standalone, the required BIOS filename for the PC-FX 1.00 BIOS is **pcfx.rom**.

In the process of porting from standalone to libretro, the MDFN_GetSettingS function was simplified from the original source (which provides settings for all of the systems that Mednafen emulates). Probably due to an errant copy paste or other oversight, the configuration variable name (**pcfx.bios**) was substituted for the filename (**pcfx.rom**) in this one line of code affected by the PR.

As a consequence, MDFN_GettingS unintentionally overrides another portion of the libretro port that *does* show the correct ROM filename: https://github.com/libretro/beetle-pcfx-libretro/blob/master/libretro.cpp#L989

This change would restore the behavior of the upstream code.

There are a few posts which go into more detail about this in the libretro-database Issue tracker: https://github.com/libretro/libretro-database/issues/373#issuecomment-271118681