### PR TITLE
match default audio behavior setting to upstream Mednafen

### DIFF
--- a/mednafen/settings.cpp
+++ b/mednafen/settings.cpp
@@ -80,7 +80,7 @@ bool MDFN_GetSettingB(const char *name)
    if (!strcmp("pcfx.nospritelimit", name))
       return 0; /* TODO - make configurable */
    if (!strcmp("pcfx.adpcm.suppress_channel_reset_clicks", name))
-      return 0; /* TODO - make configurable */
+      return 1; /* TODO - make configurable */
    if (!strcmp("pcfx.disable_bram", name))
       return 0; /* TODO - make configurable */
    if (!strcmp("pcfx.adpcm.emulate_buggy_codec", name))


### PR DESCRIPTION
This seems like a similar situation to the BIOS ROM name issue from earlier this week: https://github.com/libretro/beetle-pcfx-libretro/pull/15

In porting to libretro, the various 'get setting' functions were simplified to return only the values needed for that particular core. The default value for **pcfx.adpcm.suppress_channel_reset_clicks** in Mednafen is **1**, but it wound up as **0** in the libretro port. http://mednafen.fobby.net/documentation/pcfx.html#Settings+Reference

There are forums users who are experiencing the 'click' audio error which this PR should fix by restoring the value of **1**.