### PR TITLE
Add core options

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -2025,19 +2025,21 @@ extern void MDFND_DispMessage(unsigned char *str);
 
 void MDFN_DispMessage(const char *format, ...)
 {
- va_list ap;
- va_start(ap,format);
- char *msg = new char[4096];
+   struct retro_message msg;
+   va_list ap;
+   va_start(ap,format);
+   char *str = new char[4096];
+   const char *strc = NULL;
 
- vsnprintf(msg, 4096, format,ap);
- va_end(ap);
+   vsnprintf(str, 4096, format,ap);
+   va_end(ap);
+   strc = str;
 
- MDFND_DispMessage((UTF8*)msg);
+   msg.frames = 180;
+   msg.msg = strc;
+
+   environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE, &msg);
 }
-
-
-
-
 
 void MDFNI_CloseGame(void)
 {

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1689,7 +1689,7 @@ void retro_run()
 
 #if defined(WANT_32BPP)
    const uint32_t *pix = surf->pixels;
-   video_cb(pix, width, height, FB_WIDTH << 2);
+   video_cb(pix + surf->pitchinpix * spec.DisplayRect.y, width, height, FB_WIDTH << 2);
 #elif defined(WANT_16BPP)
    const uint16_t *pix = surf->pixels16;
    video_cb(pix, width, height, FB_WIDTH << 1);

--- a/mednafen/settings.cpp
+++ b/mednafen/settings.cpp
@@ -21,6 +21,15 @@
 #include <string>
 #include "settings.h"
 
+int setting_initial_scanline = 0;
+int setting_last_scanline = 239;
+int setting_high_dotclock_width = 1024;
+int setting_nospritelimit = 0;
+int setting_resamp_quality = 3;
+int setting_suppress_channel_reset_clicks = 1;
+int setting_emulate_buggy_codec = 0;
+int setting_rainbow_chromaip = 0;
+
 bool MDFN_SaveSettings(const char *path)
 {
    return(1);
@@ -31,13 +40,13 @@ uint64 MDFN_GetSettingUI(const char *name)
    if (!strcmp("pcfx.cdspeed", name))
       return 2;
    if (!strcmp("pcfx.slend", name))
-      return 239;
+      return setting_last_scanline;
    if (!strcmp("pcfx.slstart", name))
-      return 0;
+      return setting_initial_scanline;
    if (!strcmp("pcfx.high_dotclock_width", name))
-      return 1024; /* TODO - make configurable */
+      return setting_high_dotclock_width;
    if (!strcmp("pcfx.resamp_quality", name))
-      return 3; /* TODO - make configurable */
+      return setting_resamp_quality;
 
    fprintf(stderr, "unhandled setting UI: %s\n", name);
    return 0;
@@ -71,22 +80,20 @@ bool MDFN_GetSettingB(const char *name)
       return 0;
    if (!strcmp("pcfx.disable_softreset", name))
       return 0; /* TODO - make configurable */
-   if (!strcmp("pcfx.disable_softreset", name))
-      return 0; /* TODO - make configurable */
    if (!strcmp("pcfx.input.port1.multitap", name))
       return 0; /* TODO - make configurable */
    if (!strcmp("pcfx.input.port2.multitap", name))
       return 0; /* TODO - make configurable */
    if (!strcmp("pcfx.nospritelimit", name))
-      return 0; /* TODO - make configurable */
+      return setting_nospritelimit;
    if (!strcmp("pcfx.adpcm.suppress_channel_reset_clicks", name))
-      return 1; /* TODO - make configurable */
+      return setting_suppress_channel_reset_clicks;
    if (!strcmp("pcfx.disable_bram", name))
       return 0; /* TODO - make configurable */
    if (!strcmp("pcfx.adpcm.emulate_buggy_codec", name))
-      return 0; /* TODO - make configurable */
+      return setting_emulate_buggy_codec;
    if (!strcmp("pcfx.rainbow.chromaip", name))
-      return 0; /* TODO - make configurable */
+      return setting_rainbow_chromaip;
    /* CDROM */
    if (!strcmp("cdrom.lec_eval", name))
       return 1;

--- a/mednafen/settings.h
+++ b/mednafen/settings.h
@@ -3,6 +3,15 @@
 
 #include <string>
 
+extern int setting_initial_scanline;
+extern int setting_last_scanline;
+extern int setting_high_dotclock_width;
+extern int setting_nospritelimit;
+extern int setting_resamp_quality;
+extern int setting_suppress_channel_reset_clicks;
+extern int setting_emulate_buggy_codec;
+extern int setting_rainbow_chromaip;
+
 bool MDFN_LoadSettings(const char *path, const char *section = NULL, bool override = false);
 bool MDFN_MergeSettings(const void*);
 bool MDFN_MergeSettings(const std::vector<void> &);


### PR DESCRIPTION
**Update Summary:**
-add configurable core options
-use update_geometry()
-use environ_cb() instead of MDFND_Dispmessage(which calls for log_cb) to allow OSD notices like when switching MODE1 A/B and MODE2 A/B on gamepad
-adjust video_cb() to fix initial_scanline only adjusts bottom pixels

