### PR TITLE
Fix core not saving

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -96,7 +96,7 @@ class PtrLengthPair
 static bool MDFN_DumpToFile(const char *filename, int compress,
       const std::vector<PtrLengthPair> &pearpairs)
 {
-   RFILE *fp = filestream_open(filename, RETRO_VFS_FILE_ACCESS_READ, 
+   RFILE *fp = filestream_open(filename, RETRO_VFS_FILE_ACCESS_WRITE, 
          RETRO_VFS_FILE_ACCESS_HINT_NONE);
 
    if (!fp)


### PR DESCRIPTION
https://github.com/libretro/beetle-pcfx-libretro/issues/40
This should probably be RETRO_VFS_FILE_ACCESS_WRITE instead?

changing this enables saving in my testt but not familiar with VFS so confimation and proper fix is needed.

*reviews needed*