### PR TITLE
Compilation fix

### DIFF
--- a/mednafen/hw_cpu/v810/v810_fp_ops.cpp
+++ b/mednafen/hw_cpu/v810/v810_fp_ops.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "v810_fp_ops.h"
+#include <algorithm>
 
 bool V810_FP_Ops::fp_is_zero(uint32 v)
 {


### PR DESCRIPTION
Line 1607 in libretro.cpp is also broken
```
deint.Process(spec.surface, spec.DisplayRect, spec.LineWidths, spec.InterlaceField);
```

`spec.LineWidths` is int32 but deint.Process takes a `MDFN_Rect` for that parameter.
How is this even compiling in Travis?
