### PR TITLE
makefile: Remove erroneous -marm argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ else ifneq (,$(findstring cortexa9,$(platform)))
    FLAGS += -marm -mcpu=cortex-a9
    ASFLAGS += -mcpu=cortex-a9
 endif
-   FLAGS += -marm
+
 ifneq (,$(findstring neon,$(platform)))
    FLAGS += -mfpu=neon
    ASFLAGS += -mfpu=neon


### PR DESCRIPTION
There are platform conditionals for the -marm flag. It is not needed in this context.

Fixes #50