### PR TITLE
Updated internal core name to Beetle PC-FX

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -981,7 +981,7 @@ static Deinterlacer deint;
 #endif
 
 #define MEDNAFEN_CORE_NAME_MODULE "pcfx"
-#define MEDNAFEN_CORE_NAME "Mednafen PC-FX"
+#define MEDNAFEN_CORE_NAME "Beetle PC-FX"
 #define MEDNAFEN_CORE_VERSION "v0.9.36.5"
 #define MEDNAFEN_CORE_EXTENSIONS "cue|ccd|toc|chd"
 #define MEDNAFEN_CORE_TIMING_FPS 59.94


### PR DESCRIPTION
Previously was internally Mednafen PC-FX. This change will result in changing the save/state/cheat directory names and the config/override names, but that shouldn't be of great concern since this system has seen minimal usage up to this point. Due to the next RALibretro update adding PC-FX support for achievement development, merging this before more users get interested would be preferable.