### PR TITLE
Makefile: fix cross-compile for ARM platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ else ifneq (,$(findstring CortexA73_G12B,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
-   CC = gcc
+   CC ?= gcc
    LDFLAGS += $(PTHREAD_FLAGS)
    FLAGS += $(PTHREAD_FLAGS)
    IS_X86 = 0
@@ -124,7 +124,7 @@ else ifneq (,$(findstring S905,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
-   CC = gcc
+   CC ?= gcc
    LDFLAGS += $(PTHREAD_FLAGS)
    FLAGS += $(PTHREAD_FLAGS)
    IS_X86 = 0
@@ -136,7 +136,7 @@ else ifneq (,$(findstring SM1,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
-   CC = gcc
+   CC ?= gcc
    LDFLAGS += $(PTHREAD_FLAGS)
    FLAGS += $(PTHREAD_FLAGS)
    IS_X86 = 0
@@ -148,7 +148,7 @@ else ifneq (,$(findstring rpi4,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
-   CC = gcc
+   CC ?= gcc
    LDFLAGS += $(PTHREAD_FLAGS)
    FLAGS += $(PTHREAD_FLAGS)
    IS_X86 = 0
@@ -294,7 +294,7 @@ else ifneq (,$(findstring armv,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
-   CC = gcc
+   CC ?= gcc
    LDFLAGS += $(PTHREAD_FLAGS)
    FLAGS += $(PTHREAD_FLAGS)
    IS_X86 = 0


### PR DESCRIPTION
Only define `CC = gcc` if `CC` was not defined before.