### PR TITLE
Add support for 16 bpp color format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 CACHE_CD = 0
 
 core = pcfx
-NEED_BPP = 32
+NEED_BPP ?= 32
 ifneq ($(platform), osx)
 	PTHREAD_FLAGS = -pthread
 endif

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -1503,6 +1503,7 @@ bool retro_load_game(const struct retro_game_info *info)
 
    environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
 
+#ifdef WANT_32BPP
    enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_XRGB8888;
    if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt))
    {
@@ -1510,6 +1511,15 @@ bool retro_load_game(const struct retro_game_info *info)
          log_cb(RETRO_LOG_ERROR, "Pixel format XRGB8888 not supported by platform, cannot use %s.\n", MEDNAFEN_CORE_NAME);
       return false;
    }
+#elif WANT_16BPP
+   enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_RGB565;
+   if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt))
+   {
+      if (log_cb)
+         log_cb(RETRO_LOG_ERROR, "Pixel format RGB565 not supported by platform, cannot use %s.\n", MEDNAFEN_CORE_NAME);
+      return false;
+   }
+#endif
 
    check_variables(false);
 
@@ -1525,9 +1535,15 @@ bool retro_load_game(const struct retro_game_info *info)
       return false;
 
    struct MDFN_PixelFormat pix_fmt;
+   void *pixbuf;
 
+#ifdef WANT_32BPP
    pix_fmt.bpp        = 32;
+#elif WANT_16BPP
+   pix_fmt.bpp        = 16;
+#endif
    pix_fmt.colorspace = MDFN_COLORSPACE_RGB;
+   // placeholders since we use MAKECOLOR macro
    pix_fmt.Rshift     = 16;
    pix_fmt.Gshift     = 8;
    pix_fmt.Bshift     = 0;
@@ -1541,11 +1557,15 @@ bool retro_load_game(const struct retro_game_info *info)
    last_pixel_format.Ashift     = 0;
 
    surf.format                  = pix_fmt;
-   surf.pixels                  = (uint32 *)calloc(1, FB_WIDTH * FB_HEIGHT * (pix_fmt.bpp / 8));
 
-   if (!surf.pixels)
+   if (!(pixbuf = calloc(1, FB_WIDTH * FB_HEIGHT * (pix_fmt.bpp / 8))))
       return false;
 
+#ifdef WANT_32BPP   
+   surf.pixels                  = (uint32 *)pixbuf;
+#elif WANT_16BPP   
+   surf.pixels16                = (uint16 *)pixbuf;
+#endif
    surf.w                       = FB_WIDTH;
    surf.h                       = FB_HEIGHT;
    surf.pitchinpix              = FB_WIDTH;
@@ -1716,7 +1736,11 @@ void retro_run()
    width  = spec.DisplayRect.w;
    height = spec.DisplayRect.h;
 
+#ifdef WANT_32BPP
    video_cb(surf.pixels + surf.pitchinpix * spec.DisplayRect.y, width, height, FB_WIDTH << 2);
+#elif WANT_16BPP
+   video_cb(surf.pixels16 + surf.pitchinpix * spec.DisplayRect.y, width, height, FB_WIDTH << 1);
+#endif
 
    bool updated = false;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
@@ -1761,10 +1785,16 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 
 void retro_deinit()
 {
+#ifdef WANT_32BPP
    if(surf.pixels)
       free(surf.pixels);
+#elif WANT_16BPP
+   if(surf.pixels16)
+      free(surf.pixels16);
+#endif
 
    surf.pixels            = NULL;
+   surf.pixels16          = NULL;
    surf.w                 = 0;
    surf.h                 = 0;
    surf.pitchinpix        = 0;

--- a/mednafen/pcfx/king.cpp
+++ b/mednafen/pcfx/king.cpp
@@ -2196,7 +2196,6 @@ static void DrawBG(uint32 *target, int n, bool sub)
 
 static int16 UVLUT[65536][3];
 static uint8 RGBDeflower[1152]; // 0 is at 384
-static uint32 CbCrLUT[65536];
 
 static void RebuildUVLUT(const MDFN_PixelFormat &format)
 {
@@ -2218,11 +2217,6 @@ static void RebuildUVLUT(const MDFN_PixelFormat &format)
    UVLUT[vr + ur * 256][0] = r;
    UVLUT[vr + ur * 256][1] = g;
    UVLUT[vr + ur * 256][2] = b;
- 
-   // CbCrLUT[vr + ur * 256] = clamp_to_u8(128 + ((r * -9699 + g * -19071 + b * 28770) >> 16)) << format.Cbshift;
-   // CbCrLUT[vr + ur * 256] |= clamp_to_u8(128 + ((r * 28770 + g * -24117 + b * -4653) >> 16)) << format.Crshift;
-
-   //printf("%d %d %d, %08x\n", r, g, b, CbCrLUT[vr + ur * 256]);
   }
  }
  for(int x = 0; x < 1152; x++)
@@ -2262,15 +2256,6 @@ static uint32 INLINE YUV888_TO_PF(const uint32 yuv)
  b = clamp_to_u8((int32)(y + UVLUT[yuv & 0xFFFF][2]));
 
  return MAKECOLOR(r, g, b, 0);
-}
-
-static uint32 INLINE YUV888_TO_YCbCr888(uint32 yuv)
-{
- uint32 y;
-
- y = 16 + ((((yuv >> 16) & 0xFF) * 220) >> 8);
-
- return(y | CbCrLUT[yuv & 0xFFFF]);
 }
 
 // FIXME: 
@@ -2761,18 +2746,10 @@ static void MixLayers(void)
       target[x] = YUV888_TO_xxx(zeout);	\
      }
 
-    /*if(surface->format.colorspace == MDFN_COLORSPACE_YCbCr)
-    {
-     #define YUV888_TO_xxx YUV888_TO_YCbCr888
-     #include "king_mix_body.inc"
-     #undef YUV888_TO_xxx
-    }
-    else*/
-    {
-     #define YUV888_TO_xxx YUV888_TO_PF
-     #include "king_mix_body.inc"
-     #undef YUV888_TO_xxx
-    }
+    #define YUV888_TO_xxx YUV888_TO_PF
+    #include "king_mix_body.inc"
+    #undef YUV888_TO_xxx
+
     DisplayRect->w = fx_vce.dot_clock ? HighDotClockWidth : 256;
     DisplayRect->x = 0;
 

--- a/mednafen/pcfx/king.cpp
+++ b/mednafen/pcfx/king.cpp
@@ -2519,11 +2519,7 @@ static void MixVDC(void)
 
 static void MixLayers(void)
 {
-#ifdef WANT_32BPP
-   uint32 *pXBuf = surface->pixels;
-#elif WANT_16BPP
-   uint16 *pXBuf = surface->pixels16;
-#endif
+   bpp_t *pXBuf = surface->pixels;
 
     // Now we have to mix everything together... I'm scared, mommy.
     // We have, vdc_linebuffer[0] and bg_linebuffer
@@ -2573,12 +2569,7 @@ static void MixLayers(void)
      coeff_cache_v_back[x] = vce_rendercache.coefficient_mul_table_uv[(vce_rendercache.coefficients[x * 2 + 1] >> 0) & 0xF];
     }
 
-    //uint32 *target;
-#ifdef WANT_32BPP
-    uint32 *target;
-#elif WANT_16BPP
-    uint16 *target;
-#endif
+    bpp_t *target;
     uint32 BPC_Cache = (LAYER_NONE << 28); // Backmost pixel color(cache)
 
     if(fx_vce.frame_interlaced)

--- a/mednafen/video/surface.h
+++ b/mednafen/video/surface.h
@@ -6,12 +6,14 @@
 // Core only supports 32bpp format
 
 #if defined(WANT_32BPP)
+typedef uint32 bpp_t;
 #define RED_SHIFT 16
 #define GREEN_SHIFT 8
 #define BLUE_SHIFT 0
 #define ALPHA_SHIFT 24
 #define MAKECOLOR(r, g, b, a) ((r << RED_SHIFT) | (g << GREEN_SHIFT) | (b << BLUE_SHIFT) | (a << ALPHA_SHIFT))
 #elif defined(WANT_16BPP) && defined(FRONTEND_SUPPORTS_RGB565)
+typedef uint16 bpp_t;
 #define RED_EXPAND 3
 #define GREEN_EXPAND 2
 #define BLUE_EXPAND 3
@@ -44,8 +46,7 @@ struct MDFN_PixelFormat
 
 struct MDFN_Surface //typedef struct
 {
-   uint32 *pixels;
-   uint16 *pixels16;
+   bpp_t *pixels;
 
    // w, h, and pitch32 should always be > 0
    int32 w;

--- a/mednafen/video/surface.h
+++ b/mednafen/video/surface.h
@@ -5,11 +5,21 @@
 
 // Core only supports 32bpp format
 
+#if defined(WANT_32BPP)
 #define RED_SHIFT 16
 #define GREEN_SHIFT 8
 #define BLUE_SHIFT 0
 #define ALPHA_SHIFT 24
 #define MAKECOLOR(r, g, b, a) ((r << RED_SHIFT) | (g << GREEN_SHIFT) | (b << BLUE_SHIFT) | (a << ALPHA_SHIFT))
+#elif defined(WANT_16BPP) && defined(FRONTEND_SUPPORTS_RGB565)
+#define RED_EXPAND 3
+#define GREEN_EXPAND 2
+#define BLUE_EXPAND 3
+#define RED_SHIFT 11
+#define GREEN_SHIFT 5
+#define BLUE_SHIFT 0
+#define MAKECOLOR(r, g, b, a) (((r >> RED_EXPAND) << RED_SHIFT) | ((g >> GREEN_EXPAND) << GREEN_SHIFT) | ((b >> BLUE_EXPAND) << BLUE_SHIFT))
+#endif
 
 typedef struct
 {
@@ -35,6 +45,7 @@ struct MDFN_PixelFormat
 struct MDFN_Surface //typedef struct
 {
    uint32 *pixels;
+   uint16 *pixels16;
 
    // w, h, and pitch32 should always be > 0
    int32 w;


### PR DESCRIPTION
32bpp color is still set as default. To build 16 bpp, just add
NEED_BPP=16 when compiling. FRONTEND_SUPPORTS_RGB should also be set to
1.

Will the core be faster than 32bpp? dunno, don't have a proper way to test it. 

@twinaphex @hunterk @hizzlekizzle 
I'll let you guys decide if we want 16bpp to be set as the default.
